### PR TITLE
[알려진 이슈] Windows SDK 10 버전의 사용에 대하여

### DIFF
--- a/WarpApiClient/Client/Client.vcxproj
+++ b/WarpApiClient/Client/Client.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{090FFBA5-33EF-41C6-BD80-A6427F747A0A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Client</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
알려진 이슈는 Windows SDK 10 버전을 사용하여 생기는 문제입니다. 레거시 SDK인 8.1을 두고, 사용자가 특정하여 설치하여야 하는 10 버전을 굳이 사용할 필요는 없을 것 같습니다.

Windos SDK 10 버전에서 Windows.h의 변경점이 거의 없으며, 본 repository에 굳이 Windows SDK 10 버전의 API가 필요한지에 대해서 의문을 제기합니다.